### PR TITLE
Add a rudimentary way to run flickr_url_parser from the command line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v1.1.0 - Unreleased
+
+Add the ability to run flickr_url_parser from the command line.
+
 ## v1.0.0 - 2023-10-17
 
 Initial release of this code as a standalone library.

--- a/README.md
+++ b/README.md
@@ -5,17 +5,15 @@ You enter a Flickr URL, and it tells you what sort of URL it is.
 
 Examples:
 
-```pycon
->>> from flickr_url_parser import parse_flickr_url
+```console
+$ flickr_url_parser "https://www.flickr.com/photos/sdasmarchives/50567413447"
+{"type": "single_photo", "photo_id": "50567413447"}
 
->>> parse_flickr_url('https://www.flickr.com/photos/sdasmarchives/50567413447')
-{'type': 'single_photo', 'photo_id': '50567413447'}
+$ flickr_url_parser "https://www.flickr.com/photos/aljazeeraenglish/albums/72157626164453131"
+{"type": "album", "user_url": "https://www.flickr.com/photos/aljazeeraenglish", "album_id": "72157626164453131"}
 
->>> parse_flickr_url('https://www.flickr.com/photos/aljazeeraenglish/albums/72157626164453131')
-{'type': 'album', 'user_url': 'https://www.flickr.com/photos/aljazeeraenglish', 'album_id': '72157626164453131'}
-
->>> parse_flickr_url('https://www.flickr.com/people/blueminds/')
-{'type': 'user', 'user_url': 'https://www.flickr.com/photos/blueminds'}
+$ flickr_url_parser "https://www.flickr.com/people/blueminds/"
+{"type": "user", "user_url": "https://www.flickr.com/photos/blueminds"}
 ```
 
 This was extracted as a standalone bit of functionality from [Flinumeratr], a toy that shows you a list of photos that can be viewed at a Flickr URL.
@@ -24,14 +22,35 @@ This was extracted as a standalone bit of functionality from [Flinumeratr], a to
 
 ## Usage
 
-See the examples above.
+There are two ways to use flickr_url_parser:
 
-For more information about the possible return values from the function, use the `help` function:
+1.  **As a command-line tool.**
+    Run `flickr_url_parser`, passing the Flickr URL as a single argument:
+    
+    ```console
+    $ flickr_url_parser "https://www.flickr.com/photos/sdasmarchives/50567413447"
+    {"type": "single_photo", "photo_id": "50567413447"}
+    ```
+    
+    The result will be printed as a JSON object.
+    
+    To see more information about the possible return values, run `flickr_url_parser --help`.
 
-```pycon
->>> from flickr_url_parser import parse_flickr_url
->>> help(parse_flickr_url)
-```
+2.  **As a Python library.**
+    Import the function `parse_flickr_url` and pass the Flickr URL as a single argument:
+
+    ```pycon
+    >>> from flickr_url_parser import parse_flickr_url
+
+    >>> parse_flickr_url("https://www.flickr.com/photos/sdasmarchives/50567413447")
+    {"type": "single_photo", "photo_id": "50567413447"}
+    ```
+    
+    To see more information about the possible return values, use the [`help` function](https://docs.python.org/3/library/functions.html#help):
+    
+    ```pycon
+    >>> help(parse_flickr_url)
+    ```
 
 ## Development
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ SOURCE = local_file("src")
 
 setuptools.setup(
     name="flickr-url-parser",
-    version="0.9.0",
+    version="1.0.0",
     author="Flickr Foundation",
     author_email="hello@flickr.org",
     readme="README.md",
@@ -51,4 +51,9 @@ setuptools.setup(
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
     ],
+    entry_points={
+        "console_scripts": [
+            "flickr_url_parser = flickr_url_parser.cli:main",
+        ]
+    },
 )

--- a/src/flickr_url_parser/__init__.py
+++ b/src/flickr_url_parser/__init__.py
@@ -35,7 +35,7 @@ def parse_flickr_url(url: str):
     The return value will be a dictionary with a key ``type`` and then some
     extra keys depending on the type, e.g.
 
-        {'type': 'single_photo', 'photo_id': '50567413447'}
+        {"type": "single_photo", "photo_id": "50567413447"}
 
     Possible values for ``type``:
 

--- a/src/flickr_url_parser/cli.py
+++ b/src/flickr_url_parser/cli.py
@@ -1,0 +1,25 @@
+import json
+import sys
+import textwrap
+
+from flickr_url_parser import parse_flickr_url
+
+
+def run_cli(argv):
+    try:
+        url = argv[1]
+    except IndexError:
+        print(f"Usage: {__file__} <URL>", file=sys.stderr)
+        return 1
+
+    if url == "--help":
+        print(textwrap.dedent(parse_flickr_url.__doc__).strip())
+        return 0
+    else:
+        print(json.dumps(parse_flickr_url(url)))
+        return 0
+
+
+def main():  # pragma: no cover
+    rc = run_cli(argv=sys.argv)
+    sys.exit(rc)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,41 @@
+import json
+
+from flickr_url_parser.cli import run_cli
+
+
+def test_run_cli(capsys):
+    rc = run_cli(
+        argv=[
+            "flickr_url_parser",
+            "https://www.flickr.com/photos/coast_guard/32812033543",
+        ]
+    )
+
+    assert rc == 0
+
+    captured = capsys.readouterr()
+    assert json.loads(captured.out) == {
+        "type": "single_photo",
+        "photo_id": "32812033543",
+    }
+    assert captured.err == ""
+
+
+def test_run_cli_shows_help(capsys):
+    rc = run_cli(argv=["flickr_url_parser", "--help"])
+
+    assert rc == 0
+
+    captured = capsys.readouterr()
+    assert captured.out.startswith("Parse a Flickr URL and return some key information")
+    assert captured.err == ""
+
+
+def test_run_cli_throws_err(capsys):
+    rc = run_cli(argv=["flickr_url_parser"])
+
+    assert rc == 1
+
+    captured = capsys.readouterr()
+    assert captured.out.startswith("")
+    assert captured.err.startswith("Usage:")


### PR DESCRIPTION
This is primarily for debugging purposes – I'm working my way through a snapshot of "weird" URLs that came out of Wikimedia Commons, and I want an easy way to see how the tool handles them without writing a unit test.