### PR TITLE
Parse two examples of URLs from the Wikimedia Commons SDC snapshot

### DIFF
--- a/src/flickr_url_parser/__init__.py
+++ b/src/flickr_url_parser/__init__.py
@@ -153,10 +153,11 @@ def parse_flickr_url(url: str):
     #
     #     https://www.flickr.com/photos/cat_tac/albums/72157666833379009
     #     https://www.flickr.com/photos/cat_tac/sets/72157666833379009
+    #     https://www.flickr.com/photos/193182355@N05/albums/72157719487919133/with/51288024275/
     #
     if (
         is_long_url
-        and len(u.path) == 4
+        and len(u.path) >= 4
         and u.path[0] == "photos"
         and u.path[2] in {"albums", "sets"}
         and u.path[3].isnumeric()

--- a/src/flickr_url_parser/__init__.py
+++ b/src/flickr_url_parser/__init__.py
@@ -149,6 +149,25 @@ def parse_flickr_url(url: str):
     if is_short_url and len(u.path) == 2 and u.path[0] == "p" and is_base58(u.path[1]):
         return {"type": "single_photo", "photo_id": base58_decode(u.path[1])}
 
+    # The URL for a single photo in the context of a user's photo stream
+    #
+    #     https://www.flickr.com/photos/94631446@N03/with/12121355904/
+    #
+    # When you open this page in your browser, you get shown the user's
+    # photo stream scrolled to this photo -- it's sometimes used in
+    # Wikimedia Commons data to mean "this photo".
+    if (
+        is_long_url
+        and len(u.path) == 4
+        and u.path[0] == "photos"
+        and u.path[2] == "with"
+        and u.path[3].isnumeric()
+    ):
+        return {
+            "type": "single_photo",
+            "photo_id": u.path[3],
+        }
+
     # The URL for an album, e.g.
     #
     #     https://www.flickr.com/photos/cat_tac/albums/72157666833379009

--- a/tests/test_flickr_url_parser.py
+++ b/tests/test_flickr_url_parser.py
@@ -73,18 +73,36 @@ def test_it_parses_a_single_photo(url, photo_id):
 
 
 @pytest.mark.parametrize(
-    "url",
+    ("url", "expected"),
     [
-        "https://www.flickr.com/photos/cat_tac/albums/72157666833379009",
-        "https://www.flickr.com/photos/cat_tac/sets/72157666833379009",
+        (
+            "https://www.flickr.com/photos/cat_tac/albums/72157666833379009",
+            {
+                "type": "album",
+                "user_url": "https://www.flickr.com/photos/cat_tac",
+                "album_id": "72157666833379009",
+            },
+        ),
+        (
+            "https://www.flickr.com/photos/cat_tac/sets/72157666833379009",
+            {
+                "type": "album",
+                "user_url": "https://www.flickr.com/photos/cat_tac",
+                "album_id": "72157666833379009",
+            },
+        ),
+        (
+            "https://www.flickr.com/photos/193182355@N05/albums/72157719487919133/with/51288024275/",
+            {
+                "type": "album",
+                "user_url": "https://www.flickr.com/photos/193182355@N05",
+                "album_id": "72157719487919133",
+            },
+        ),
     ],
 )
-def test_it_parses_an_album(url):
-    assert parse_flickr_url(url) == {
-        "type": "album",
-        "user_url": "https://www.flickr.com/photos/cat_tac",
-        "album_id": "72157666833379009",
-    }
+def test_it_parses_an_album(url, expected):
+    assert parse_flickr_url(url) == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/test_flickr_url_parser.py
+++ b/tests/test_flickr_url_parser.py
@@ -63,6 +63,7 @@ def test_it_can_parse_urls_even_if_the_host_is_a_bit_unusual(url):
         ),
         ("https://www.flickr.com/photos/11588490@n02/2174280796/sizes/l", "2174280796"),
         ("https://www.flickr.com/photos/nrcs_south_dakota/8023844010/in", "8023844010"),
+        ("https://www.flickr.com/photos/94631446@N03/with/12121355904/", "12121355904"),
     ],
 )
 def test_it_parses_a_single_photo(url, photo_id):


### PR DESCRIPTION
These are both interesting examples of URLs and I'm not sure how to handle them: they point to a collection of photos (an album or a photostream) but then use the `/with/<photo ID>` path component to highlight a specific image.

I need to think about how to model these in the result type before merging this.