### PR TITLE
Tighten up the definition of 'numeric ID' in a Flickr URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## NEXT - unreleased
+
+*   Tighten up the definition of "numeric ID" in Flickr URLs, so only something that could plausibly be a numeric ID is allowed.
+
+    e.g. `https://www.flickr.com/photos/circled/①②③` will no longer be returned as a plausible photo URL.
+
 ## v1.1.0 - 2023-10-18
 
 *   Add the ability to run flickr_url_parser from the command line.

--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ There are two ways to use flickr_url_parser:
     >>> help(parse_flickr_url)
     ```
 
+Note that just because a URL can be parsed does not mean it can be *resolved* to a photo and/or photos.
+The only way to know if there are photos behind the URL is to (1) try to fetch the URL or (2) use the output from the parser to ask the Flickr API for photos.
+
 ## Development
 
 You can set up a local development environment by cloning the repo and installing dependencies:

--- a/src/flickr_url_parser/__init__.py
+++ b/src/flickr_url_parser/__init__.py
@@ -24,7 +24,25 @@ class UnrecognisedUrl(Exception):
 
 
 def is_page(path_component):
-    return re.match(r"^page\d+$", path_component)
+    return re.match(r"^page[0-9]+$", path_component)
+
+
+def is_digits(path_component):
+    """
+    Returns True if ``path_component`` is a non-empty string of
+    digits 0-9, False otherwise.
+
+    Note: this is different from ``str.isdigit()`` or ``str.isnumeric()``,
+    both of which admit a wider range of characters that we wouldn't
+    expect to see in a Flickr URL.
+
+        >>> '①'.isdigit()
+        True
+        >>> '½'.isnumeric()
+        True
+
+    """
+    return re.match(r"^[0-9]+$", path_component)
 
 
 def parse_flickr_url(url: str):
@@ -133,7 +151,7 @@ def parse_flickr_url(url: str):
         is_long_url
         and len(u.path) >= 3
         and u.path[0] == "photos"
-        and u.path[2].isnumeric()
+        and is_digits(u.path[2])
     ):
         return {
             "type": "single_photo",
@@ -159,7 +177,7 @@ def parse_flickr_url(url: str):
         and len(u.path) == 4
         and u.path[0] == "photos"
         and u.path[2] in {"albums", "sets"}
-        and u.path[3].isnumeric()
+        and is_digits(u.path[3])
     ):
         return {
             "type": "album",
@@ -248,7 +266,7 @@ def parse_flickr_url(url: str):
         and len(u.path) >= 4
         and u.path[0] == "photos"
         and u.path[2] in {"gallery", "galleries"}
-        and u.path[3].isnumeric()
+        and is_digits(u.path[3])
     ):
         return {"type": "gallery", "gallery_id": u.path[3]}
 

--- a/tests/test_flickr_url_parser.py
+++ b/tests/test_flickr_url_parser.py
@@ -18,7 +18,21 @@ def test_it_rejects_a_url_which_isnt_flickr(url):
 
 
 @pytest.mark.parametrize(
-    "url", ["https://www.flickr.com", "https://www.flickr.com/account/email"]
+    "url",
+    [
+        "https://www.flickr.com",
+        "https://www.flickr.com/account/email",
+        # The characters in these examples are drawn from the
+        # Unicode Numeric Property Definitions:
+        # https://www.unicode.org/L2/L2012/12310-numeric-type-def.html
+        #
+        # In particular, all of these are characters that return True
+        # for Python's ``str.isnumeric()`` function, but we don't expect
+        # to see in a Flickr URL.
+        "https://www.flickr.com/photos/fractions/½⅓¼⅕⅙⅐",
+        "https://www.flickr.com/photos/circled/sets/①②③",
+        "https://www.flickr.com/photos/numerics/galleries/Ⅰ፩൲〡",
+    ],
 )
 def test_it_rejects_a_flickr_url_which_does_have_photos(url):
     with pytest.raises(UnrecognisedUrl):


### PR DESCRIPTION
It struck me while doing error handling elsewhere that `str.isnumeric()` != `[0-9]+`.